### PR TITLE
TD-3857:  update artifact github action

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -11,6 +11,10 @@ jobs:
     outputs:
       on_main: ${{ steps.contains_tag.outputs.retval }}
     steps:
+      # refer to https://github.com/rickstaa/action-contains-tag/pull/18 for more info
+      - name: Workaround regression action-contains-tag due to git update
+        run: git config --global remote.origin.followRemoteHEAD never
+
       - name: Git checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
to fix the following error, which is because of rickstaa/action-contains-tag bug.
```
[action-contains-tag] Branch 'remotes/origin/HEAD -> origin/main' does not contain tag '1.4.2'.