### PR TITLE
TD-3178: Fix RedisClusterCleanup not found

### DIFF
--- a/internal/controller/redisclustercleanup/redisclustercleanup_controller.go
+++ b/internal/controller/redisclustercleanup/redisclustercleanup_controller.go
@@ -64,7 +64,7 @@ func (r *RedisClusterCleanupReconciler) Reconcile(ctx context.Context, req ctrl.
 	redisClusterCleanup := &redisv1alpha1.RedisClusterCleanup{}
 	if err := r.Get(ctx, req.NamespacedName, redisClusterCleanup); err != nil {
 		logger.Info("Failed to get RedisClusterCleanup", "error", err.Error())
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, client.IgnoreNotFound(err)
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	if redisClusterCleanup.Spec.Suspend {


### PR DESCRIPTION
Basically, if we requeue the reconcile event, deleting the RedisClusterCleanup resource will cause it to get stuck in a reconcile loop. So, when the resource is not found, we should simply return without requeuing.